### PR TITLE
Implemented handling MQTT disconnect messages.

### DIFF
--- a/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/PubSub.java
+++ b/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/PubSub.java
@@ -67,6 +67,14 @@ public interface PubSub {
   void unsubscribe(UnsubscribeMessage msg);
 
   /**
+   * Unsubscribes from all topics the specified client is subscribed to using the underlying
+   * Pub/Sub implementation.
+   *
+   * @param clientId the id of the disconnecting client.
+   */
+  void disconnect(String clientId);
+
+  /**
    * Relinquishes the pubsub resources. This method will be invoked when the proxy
    * no longer requires the pubsub instance.
    */

--- a/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/gcloud/GcloudPubsub.java
+++ b/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/gcloud/GcloudPubsub.java
@@ -448,6 +448,19 @@ public final class GcloudPubsub implements PubSub {
   }
 
   @Override
+  public synchronized void disconnect(String clientId) {
+    Map<String, Set<String>> mqttTopicMap = clientIdSubscriptionMap.get(clientId);
+    if (mqttTopicMap != null) {
+      // create a new set, because it will get updated on unsubscribe
+      // note: once a client is disconnected, the only acceptable control packet is a connect
+      Set<String> mqttTopics = new HashSet<>(mqttTopicMap.keySet());
+      for (String mqttTopic : mqttTopics) {
+        updateOnUnsubscribe(clientId, mqttTopic);
+      }
+    }
+  }
+
+  @Override
   public void destroy() {
     pubsub = null;
     taskExecutor.shutdown();

--- a/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/moquette/PubsubHandler.java
+++ b/mqtt_cloud_pubsub_proxy/src/main/java/com/google/cloud/pubsub/proxy/moquette/PubsubHandler.java
@@ -100,7 +100,8 @@ public class PubsubHandler extends ChannelInboundHandlerAdapter {
           handleUnsubscribeMessage(mqttMsg, clientId);
           break;
         case DISCONNECT:
-          // TODO unsubscribe from all subscriptions for the specific client id
+          logger.info("Processing MQTT Disconnect Control Packet");
+          pubsub.disconnect(clientId);
           break;
         default:
           break;


### PR DESCRIPTION
Contains the implementation for handing MQTT disconnect control packets. Updates internal subscription data structures and terminates Cloud Pub/Sub pull tasks when there are no more client subscriptions for the pubsub topic.
