### PR TITLE
Update the deprecation notice to point to the MQTT <-> Cloud Pub/Sub connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-DEPRECATED
-
-Google provides [MQTT bridge](https://cloud.google.com/iot/docs/how-tos/mqtt-bridge) as part of our Cloud IoT offerings. We recommend that you consider using the MQTT bridge.
+This repository is archived, and no further development is expected. If you need a solution to integrate a MQTT broker with Cloud Pub/Sub, refer to https://github.com/GoogleCloudPlatform/mqtt-cloud-pubsub-connector
 
 ## What is MQTT Cloud Pub/Sub Proxy?
 


### PR DESCRIPTION
This PR updates the deprecation notice to point to https://github.com/GoogleCloudPlatform/mqtt-cloud-pubsub-connector instead of IoT Core.